### PR TITLE
Add max_by_key and min_by_key functions to InternalIterator.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,6 +509,13 @@ pub trait InternalIterator: Sized {
         max
     }
 
+    /// Returns the element that gives the maximum value from the specified function.
+    fn max_by_key<B: Ord>(self, mut key: impl FnMut(&Self::Item) -> B) -> Option<Self::Item> {
+        self.map(|x| (key(&x), x))
+            .max_by(|(kx, _), (ky, _)| kx.cmp(ky))
+            .map(|(_, x)| x)
+    }
+
     /// Returns the minimum element of an iterator.
     ///
     /// ```
@@ -542,6 +549,13 @@ pub trait InternalIterator: Sized {
             }
         });
         min
+    }
+
+    /// Returns the element that gives the maximum value from the specified function.
+    fn min_by_key<B: Ord>(self, mut key: impl FnMut(&Self::Item) -> B) -> Option<Self::Item> {
+        self.map(|x| (key(&x), x))
+            .min_by(|(kx, _), (ky, _)| kx.cmp(ky))
+            .map(|(_, x)| x)
     }
 
     /// Returns the first element of the iterator.


### PR DESCRIPTION
I added `max_by_key` and `min_by_key`, two functions that are in the normal `Iterator` but were missing in this one. I needed them for one of my projects.

The implementation is pretty much the same as the one in `std`, but a bit more modern.