### PR TITLE
Add IntoInternalIterator impls for builtin collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ let internal_iterator_result = tree
     .into_internal_iter()
     .map(|x| x * 2)
     .filter(|&x| x > 5)
-    .flat_map(|x| [x, x * 10].into_iter().into_internal())
+    .flat_map(|x| [x, x * 10])
     .collect::<Vec<_>>();
 
 assert_eq!(internal_iterator_result, vec![8, 80, 6, 60, 10, 100]);

--- a/src/alloc_impls.rs
+++ b/src/alloc_impls.rs
@@ -1,5 +1,5 @@
 use alloc::{string::String, vec::Vec, collections::{BTreeMap, BTreeSet}};
-use crate::{FromInternalIterator, InternalIterator, IntoInternalIterator};
+use crate::{FromInternalIterator, InternalIterator, IntoInternalIterator, IteratorExt};
 
 impl<A> FromInternalIterator<A> for Vec<A> {
     fn from_iter<T>(iter: T) -> Self
@@ -51,4 +51,15 @@ impl<K: Ord, V> FromInternalIterator<(K, V)> for BTreeMap<K, V> {
         });
         result
     }
+}
+
+crate::into_internal_impls! {
+    ['a, T] &'a Vec<T>,
+    ['a, T] &'a mut Vec<T>,
+    [T] Vec<T>,
+    ['a, T] &'a BTreeSet<T>,
+    [T] BTreeSet<T>,
+    ['a, K, V] &'a BTreeMap<K, V>,
+    ['a, K, V] &'a mut BTreeMap<K, V>,
+    [K, V] BTreeMap<K, V>,
 }

--- a/src/std_impls.rs
+++ b/src/std_impls.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
-use crate::{FromInternalIterator, InternalIterator, IntoInternalIterator};
+use crate::{FromInternalIterator, InternalIterator, IntoInternalIterator, IteratorExt};
 
 impl<A: Eq + Hash> FromInternalIterator<A> for HashSet<A> {
     fn from_iter<T>(iter: T) -> Self
@@ -26,4 +26,12 @@ impl<K: Eq + Hash, V> FromInternalIterator<(K, V)> for HashMap<K, V> {
         });
         result
     }
+}
+
+crate::into_internal_impls! {
+    ['a, T] &'a HashSet<T>,
+    [T] HashSet<T>,
+    ['a, K, V] &'a HashMap<K, V>,
+    ['a, K, V] &'a mut HashMap<K, V>,
+    [K, V] HashMap<K, V>,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -190,7 +190,7 @@ fn readme_example() {
         .into_internal_iter()
         .map(|x| x * 2)
         .filter(|&x| x > 5)
-        .flat_map(|x| [x, x * 10].into_iter().into_internal())
+        .flat_map(|x| [x, x * 10])
         .collect::<Vec<_>>();
 
     assert_eq!(internal_iterator_result, vec![8, 80, 6, 60, 10, 100]);


### PR DESCRIPTION
These match popular `IntoIterator` impls, and they make `flat_map` easier to use in some cases.