### PR TITLE
Adaptor improvements

### DIFF
--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -308,4 +308,16 @@ where
     {
         self.iterator.try_for_each(consumer)
     }
+
+    fn count(self) -> usize {
+        self.iterator.count()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.iterator.last()
+    }
+
+    fn nth(mut self, n: usize) -> Option<Self::Item> {
+        self.iterator.nth(n)
+    }
 }

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -4,6 +4,7 @@ use crate::{InternalIterator, IntoInternalIterator};
 
 
 /// An iterator that links two iterators together, in a chain.
+#[derive(Clone)]
 pub struct Chain<A, B> {
     pub(crate) first: A,
     pub(crate) second: B,
@@ -30,6 +31,7 @@ where
 
 
 /// An iterator that clones the elements of an underlying iterator.
+#[derive(Clone)]
 pub struct Cloned<I> {
     pub(crate) iter: I,
 }
@@ -51,6 +53,7 @@ where
 
 
 /// An iterator that copies the elements of an underlying iterator.
+#[derive(Clone)]
 pub struct Copied<I> {
     pub(crate) iter: I,
 }
@@ -72,6 +75,7 @@ where
 
 
 /// An iterator that yields the current count and the element during iteration.
+#[derive(Clone)]
 pub struct Enumerate<I> {
     pub(crate) iter: I,
 }
@@ -97,6 +101,7 @@ where
 
 
 /// An iterator that filters the elements of `iter` with `predicate`.
+#[derive(Clone)]
 pub struct Filter<I, F> {
     pub(crate) iter: I,
     pub(crate) predicate: F,
@@ -126,6 +131,7 @@ where
 
 
 /// An iterator that uses `f` to both filter and map elements from `iter`.
+#[derive(Clone)]
 pub struct FilterMap<I, F> {
     pub(crate) iter: I,
     pub(crate) f: F,
@@ -153,6 +159,7 @@ where
 
 /// An iterator that maps each element to an iterator, and yields the elements
 /// of the produced iterators.
+#[derive(Clone)]
 pub struct FlatMap<I, F> {
     pub(crate) iter: I,
     pub(crate) f: F,
@@ -178,6 +185,7 @@ where
 
 /// An iterator that calls a function with a reference to each element before
 /// yielding it.
+#[derive(Clone)]
 pub struct Inspect<I, F> {
     pub(crate) iter: I,
     pub(crate) f: F,
@@ -204,6 +212,7 @@ where
 
 
 /// An iterator that maps the values of `iter` with `f`.
+#[derive(Clone)]
 pub struct Map<I, F> {
     pub(crate) iter: I,
     pub(crate) f: F,
@@ -227,6 +236,7 @@ where
 
 
 /// An iterator that skips over `n` elements of `iter`.
+#[derive(Clone)]
 pub struct Skip<I> {
     pub(crate) iter: I,
     pub(crate) n: usize,
@@ -256,6 +266,7 @@ where
 
 
 /// An iterator that only iterates over the first `n` iterations of `iter`.
+#[derive(Clone)]
 pub struct Take<I> {
     pub(crate) iter: I,
     pub(crate) n: usize,
@@ -292,6 +303,7 @@ where
 
 
 /// A wrapper type to convert [`std::iter::Iterator`] to [`InternalIterator`].
+#[derive(Clone)]
 pub struct Internal<I> {
     pub(crate) iterator: I,
 }


### PR DESCRIPTION
A couple of simple improvements to some of the adapters that are useful to my use case:

* Some easy performance wins for `Internal`, for example this makes `(0..n).into_internal().count()` trivially zero-cost. Similar changes can be made to many of the adaptors in this crate, but the couple I did add very little code and can achieve a lot. In theory this is a breaking change, but maybe it's not too bad.
* Derive `Clone` for all of the adaptors, just like the standard library ones. There's no real downside to this.

If either of these changes are not okay I can split up this PR, just let me know.