### PR TITLE
Optimize `InternalIterator::for_each`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,7 @@ pub trait InternalIterator: Sized {
     where
         F: FnMut(Self::Item)
     {
-        self.try_for_each::<std::convert::Infallible, _>(|item| {
+        self.try_for_each::<core::convert::Infallible, _>(|item| {
             f(item);
             ControlFlow::Continue(())
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,7 @@ pub trait InternalIterator: Sized {
     where
         F: FnMut(Self::Item)
     {
-        self.try_for_each::<(), _>(|item| {
+        self.try_for_each::<std::convert::Infallible, _>(|item| {
             f(item);
             ControlFlow::Continue(())
         });


### PR DESCRIPTION
Setting `ControlFlow`'s `B` type parameter to `std::convert::Infallible` communicates to the optimizer that the `Break` variant is never returned from the closure, so no need to check for it on each iteration.